### PR TITLE
Replace 'nuts' with 'wild'

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -85,6 +85,6 @@ Easy as that. This method takes an optional `baseAttributes` parameter to custom
 
 ### Custom Parsers
 
-If you want to build your own parser (for example, to generate HTML) you can subclass whichever one meets your needs. Go nuts.
+If you want to build your own parser (for example, to generate HTML) you can subclass whichever one meets your needs. Go wild.
 
 Enjoy.


### PR DESCRIPTION
Hi @soffes,

Thanks for the awesome library.

I replaced the use of the word "nuts" in the [Custom Parsers](https://github.com/soffes/SyntaxKit#custom-parsers) section of the README. The word "nuts" refers to people with mental or psychiatric disabilities or a fruit. I don't think you meant either.

Let's make SyntaxKit an awesome library for everyone.

💃 😸 
