### PR TITLE
Update README to reflect dependencies

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -9,7 +9,9 @@ SyntaxKit was abstracted from [Whiskey](http://usewhiskey.com).
 
 ## Building
 
-SyntaxKit is written in Swift 2 so Xcode 7 is required. There aren't any dependencies besides system frameworks.
+SyntaxKit is written in Swift 2 so Xcode 7 is required. 
+
+You can install the needed dependencies with [Carthage](https://github.com/carthage/carthage): `carthage build`
 
 
 ## Installation


### PR DESCRIPTION
A clean clone of the repo won't build, since it depends on https://github.com/soffes/x. 

I'm not really a Carthage person, so I can't speak to whether the actual correct solution is to check in dependencies or not, but for now updating the README seems like a sensible quick fix.